### PR TITLE
allow vagrant user to run `sudo -u` without password

### DIFF
--- a/definitions/Debian-jessie-amd64-netboot/base.sh
+++ b/definitions/Debian-jessie-amd64-netboot/base.sh
@@ -5,7 +5,7 @@ apt-get -y install zlib1g-dev libssl-dev libreadline-gplv2-dev
 apt-get -y install curl unzip
 
 # Set up sudo
-echo 'vagrant ALL=NOPASSWD:ALL' > /etc/sudoers.d/vagrant
+echo 'vagrant ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/vagrant
 
 # Tweak sshd to prevent DNS resolution (speed up logins)
 echo 'UseDNS no' >> /etc/ssh/sshd_config


### PR DESCRIPTION
vagrant user currently isn't able to run commands like `sudo -u <someotheruser> echo hello` without getting asked for a password. This change will fix it